### PR TITLE
Standard syntax update

### DIFF
--- a/library/building/traffic_skyscraper.e
+++ b/library/building/traffic_skyscraper.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Skyscraper buildings"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/factory/traffic_type_factory.e
+++ b/library/factory/traffic_type_factory.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Factory for traffic type."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/input/traffic_building_node_processor.e
+++ b/library/input/traffic_building_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <building> nodes."
 	date: "$Date:$"
 	revision: "$Revision:$"

--- a/library/input/traffic_building_parser.e
+++ b/library/input/traffic_building_parser.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Parser for XML building files"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/input/traffic_buildings_node_processor.e
+++ b/library/input/traffic_buildings_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <buildings> nodes."
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/input/traffic_color_node_processor.e
+++ b/library/input/traffic_color_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <color> elements."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/input/traffic_description_node_processor.e
+++ b/library/input/traffic_description_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <description> nodes."
 	date: "$Date: 2009-04-06 14:42:41 +0200 (Пн, 06 апр 2009) $"
 	revision: "$Revision: 1086 $"

--- a/library/input/traffic_file_node_processor.e
+++ b/library/input/traffic_file_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for background <file> elements."
 	date: "$Date: 2009-04-06 14:42:41 +0200 (Пн, 06 апр 2009) $"
 	revision: "$Revision: 1086 $"

--- a/library/input/traffic_landmark_node_processor.e
+++ b/library/input/traffic_landmark_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that ..."
 	author: ""
 	date: "$Date$"

--- a/library/input/traffic_line_node_processor.e
+++ b/library/input/traffic_line_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <line> nodes."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/input/traffic_line_section_node_processor.e
+++ b/library/input/traffic_line_section_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <line section> nodes."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/input/traffic_lines_node_processor.e
+++ b/library/input/traffic_lines_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <lines> nodes."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/input/traffic_map_node_processor.e
+++ b/library/input/traffic_map_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <map> nodes."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/input/traffic_map_parser.e
+++ b/library/input/traffic_map_parser.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML parser for the traffic map data."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/input/traffic_node_processor.e
+++ b/library/input/traffic_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Abstract processors for XML nodes."
 	date: "$Date: 2010-06-28 20:14:26 +0200 (Пн, 28 июн 2010) $"
 	revision: "$Revision: 1133 $"

--- a/library/input/traffic_onroad_node_processor.e
+++ b/library/input/traffic_onroad_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <onroad> nodes."
 	date: "$Date: 2007-07-24 11:47:24 +0200 (Tue, 24 Jul 2007) $"
 	revision: "$Revision: 901 $"

--- a/library/input/traffic_parse_error_constants.e
+++ b/library/input/traffic_parse_error_constants.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description:"Error constants used for XML parsing."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/input/traffic_place_node_processor.e
+++ b/library/input/traffic_place_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <place> nodes."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/input/traffic_places_node_processor.e
+++ b/library/input/traffic_places_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <places> elements."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/input/traffic_point_node_processor.e
+++ b/library/input/traffic_point_node_processor.e
@@ -1,5 +1,5 @@
-indexing
-	description: "XML processors for <point> elements. Example: <point x="3.2" y="1.7">."
+note
+	description: "XML processors for <point> elements. Example: <point x=%"3.2%" y=%"1.7%">."
 	date: "$Date: 2008-09-09 11:36:48 +0200 (Вт, 09 сен 2008) $"
 	revision: "$Revision: 1070 $"
 

--- a/library/input/traffic_polygon_node_processor.e
+++ b/library/input/traffic_polygon_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that ..."
 	author: ""
 	date: "$Date$"

--- a/library/input/traffic_road_node_processor.e
+++ b/library/input/traffic_road_node_processor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "XML processors for <road> nodes."
 	date: "$Date: 2007-07-24 11:47:24 +0200 (Tue, 24 Jul 2007) $"
 	revision: "$Revision: 901 $"

--- a/library/input/traffic_xml_input_file_parser.e
+++ b/library/input/traffic_xml_input_file_parser.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Parser for XML input files."
 	date: "$Date: 2007-09-24 11:12:13 +0200 (Пн, 24 сен 2007) $"
 	revision: "$Revision: 931 $"

--- a/library/moving/traffic_bus.e
+++ b/library/moving/traffic_bus.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Vehicles of type bus"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"
@@ -50,7 +50,7 @@ feature -- Basic operations
     	do
 			count := count + a_quantity
     	end
-    	
+
     unload(a_quantity: INTEGER) is
 			-- Load cargo or a passenger.
     	do

--- a/library/moving/traffic_cablecar.e
+++ b/library/moving/traffic_cablecar.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Vehicles of type cablecar"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/moving/traffic_dispatch_taxi.e
+++ b/library/moving/traffic_dispatch_taxi.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Taxi used for taxi dispatcher application using method call communication"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/moving/traffic_free_moving.e
+++ b/library/moving/traffic_free_moving.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that can move around the city freely (do not need to travel on streets)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_line_vehicle.e
+++ b/library/moving/traffic_line_vehicle.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Deferred class for vehicles serving a line and pursuing a schedule."
 	date: "$Date: 2006/06/06 12:23:40$"
 	revision: "$Revision$"

--- a/library/moving/traffic_moving.e
+++ b/library/moving/traffic_moving.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Deferred class for moving items in the city"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_passenger.e
+++ b/library/moving/traffic_passenger.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that use a vehicle to travel"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/moving/traffic_taxi.e
+++ b/library/moving/traffic_taxi.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Class for taxis working for a taxi office"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_taxi_office.e
+++ b/library/moving/traffic_taxi_office.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Class for taxi offices"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_train.e
+++ b/library/moving/traffic_train.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Trains"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_tram.e
+++ b/library/moving/traffic_tram.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Tram"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_trolley.e
+++ b/library/moving/traffic_trolley.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Trolleys (not yet included in the city)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/moving/traffic_vehicle.e
+++ b/library/moving/traffic_vehicle.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Deferred class for objects that can be used to transport cargo or passengers"
 	date: "$Date: 2006/06/06 12:23:40 $"
 	revision: "$Revision$"

--- a/library/moving/traffic_wagon.e
+++ b/library/moving/traffic_wagon.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Wagon objects can be used to increase the capacity of trams."
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/structure/container/traffic_event_channel.e
+++ b/library/structure/container/traffic_event_channel.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Event channel that implements a publish-subscribe mechanism"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/structure/container/traffic_event_container.e
+++ b/library/structure/container/traffic_event_container.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Superclass of containers that throw events when elements are added or removed"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/structure/container/traffic_event_linked_list.e
+++ b/library/structure/container/traffic_event_linked_list.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: 	"[
 		Linked lists that throw events whenever an element is added or removed.
 		Note: For this class the features for manipulation are publicly available!!!

--- a/library/structure/container/traffic_item_hash_table.e
+++ b/library/structure/container/traffic_item_hash_table.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Hash table that contains city items, calls add_to_city and remove_from_city on insertion and deletion, and throws events when a new item is added/removed"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/structure/graph/dispenser/inverse_heap_priority_queue.e
+++ b/library/structure/graph/dispenser/inverse_heap_priority_queue.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Heap priority queue sorted such that the item with the lowest
 		priority is placed at the head of the queue.

--- a/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_graph.e
+++ b/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed graphs, implemented on the basis
 		of an adjacency matrix.

--- a/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_undirected_weighted_graph.e
+++ b/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_undirected_weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Undirected weighted graphs, implemented
 		on the basis of an adjacency matrix.

--- a/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_weighted_graph.e
+++ b/library/structure/graph/graph/implementation/adjacency_matrix_graph/adjacency_matrix_weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed weighted graphs, implemented on the basis
 		of an adjacency matrix.

--- a/library/structure/graph/graph/implementation/linked_graph/linked_graph.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed graphs, implemented as dynamically linked structure.
 		Simple graphs, multigraphs, symmetric graphs and symmetric

--- a/library/structure/graph/graph/implementation/linked_graph/linked_graph_edge.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_graph_edge.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Graph edges used for the LINKED_GRAPH data structure.
 		]"

--- a/library/structure/graph/graph/implementation/linked_graph/linked_graph_node.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_graph_node.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Graph nodes used for the LINKED_GRAPH data structure.
 		]"

--- a/library/structure/graph/graph/implementation/linked_graph/linked_graph_weighted_edge.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_graph_weighted_edge.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Weighted graph edges used for the LINKED_GRAPH data structure.
 		]"

--- a/library/structure/graph/graph/implementation/linked_graph/linked_undirected_graph.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_undirected_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Undirected graphs, implemented as dynamically linked structure.
 		Both simple graphs and multigraphs are supported.

--- a/library/structure/graph/graph/implementation/linked_graph/linked_undirected_weighted_graph.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_undirected_weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Undirected weighted graphs, implemented as
 		dynamically linked structure.

--- a/library/structure/graph/graph/implementation/linked_graph/linked_weighted_graph.e
+++ b/library/structure/graph/graph/implementation/linked_graph/linked_weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed weighted graphs, implemented as
 		dynamically linked structure.

--- a/library/structure/graph/graph/structure/edge.e
+++ b/library/structure/graph/graph/structure/edge.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed or undirected graph edges that consist of
 		two node items and a label.
@@ -107,7 +107,7 @@ feature -- Comparison
 			-- Start and end node must be equal.
 			Result := start_node.is_equal (other.start_node) and
 					  end_node.is_equal (other.end_node)
-			
+
 			-- Consider also flipped edges in undirected graphs.
 			if not is_directed then
 				Result := Result or
@@ -182,7 +182,7 @@ feature -- Inapplicable
 feature {NONE} -- Implementation
 
 invariant
-	
+
 	nodes_not_void: start_node /= Void and end_node /= Void
 
 end -- class EDGE

--- a/library/structure/graph/graph/structure/graph_cursor.e
+++ b/library/structure/graph/graph/structure/graph_cursor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Cursors for remembering positions in graphs.
 		]"
@@ -34,7 +34,7 @@ feature {GRAPH} -- Access
 
 	current_node: G
 			-- Node at the current cursor position
-			
+
 	edge_item: EDGE [G, L]
 			-- Edge which is currently focused
 

--- a/library/structure/graph/graph/structure/node.e
+++ b/library/structure/graph/graph/structure/node.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Annotated graph nodes that can be used for graph algorithms
 		such as finding the shortest routes between two nodes.

--- a/library/structure/graph/graph/structure/undirected_graph.e
+++ b/library/structure/graph/graph/structure/undirected_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Undirected graphs without commitment to a particular representation.
 		Both simple graphs and multigraphs are supported.

--- a/library/structure/graph/graph/structure/undirected_weighted_graph.e
+++ b/library/structure/graph/graph/structure/undirected_weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Undirected weighted graphs without commitment to
 		a particular representation.

--- a/library/structure/graph/graph/structure/walkable.e
+++ b/library/structure/graph/graph/structure/walkable.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Structures of walkable containers. Walkable means that every item of
 		the container can be connected via a (directed or undirected) link to
@@ -50,7 +50,7 @@ feature -- Status report
 			not_off: not off
 		deferred
 		end
-		
+
 	exhausted: BOOLEAN is
 			-- Last `left' or `right' turned to the first link ?
 		require
@@ -59,13 +59,13 @@ feature -- Status report
 		ensure
 			no_links_always_exhausted: not has_links implies exhausted
 		end
-	
+
 	has_previous: BOOLEAN is
 			-- Is there another node in the traversal history?
 			-- Must be True in order to use the `back' command.
 		deferred
 		end
-	
+
 	is_first: BOOLEAN is
 			-- Am I on the first link ?
 		require
@@ -73,7 +73,7 @@ feature -- Status report
 			has_links: has_links
 		deferred
 		end
-	
+
 feature -- Cursor movement
 
 	left is
@@ -85,7 +85,7 @@ feature -- Cursor movement
 		ensure
 			went_around: is_first = exhausted
 		end
-		
+
 	right is
 			-- Turn to the right link.
 		require
@@ -95,7 +95,7 @@ feature -- Cursor movement
 		ensure
 			went_around: is_first = exhausted
 		end
-		
+
 	turn_to (t: like target) is
 			-- Try to turn the cursor towards `t'.
 			-- If not possible, `exhausted' will be set
@@ -134,7 +134,7 @@ feature -- Cursor movement
 			moved_to_target: item = old target
 			move_to_off: not old has_links = off
 		end
-		
+
 	start is
 			-- Turn to the first link.
 		require else
@@ -158,7 +158,7 @@ feature -- Cursor movement
 invariant
 
 	zero_link_count: not off implies (has_links = (link_count > 0))
-	
+
 	exhausted_if_no_links: (not off and not has_links) implies exhausted
 
 end -- class WALKABLE

--- a/library/structure/graph/graph/structure/weighted_edge.e
+++ b/library/structure/graph/graph/structure/weighted_edge.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed or undirected weighted graph edges that consist of
 		two node items and a label.

--- a/library/structure/graph/graph/structure/weighted_graph.e
+++ b/library/structure/graph/graph/structure/weighted_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Directed weighted graphs without commitment to a particular representation.
 		Simple graphs, multigraphs, directed graphs and symmetric graphs

--- a/library/structure/graph/graph/walker/abstract_fs_walker.e
+++ b/library/structure/graph/graph/walker/abstract_fs_walker.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		An abstract "something first search" implementation,
 		that can be transformed to "breadth first search" or

--- a/library/structure/graph/graph/walker/bfs_walker.e
+++ b/library/structure/graph/graph/walker/bfs_walker.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		The BFS walker is a LINEAR abstraction of a graph, that starts
 		on a specific node and will walk in a breadth first search order

--- a/library/structure/graph/graph/walker/dfs_walker.e
+++ b/library/structure/graph/graph/walker/dfs_walker.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		The DFS walker is a LINEAR abstraction of a graph, that starts
 		on a specific node and will walk in a depth first search order

--- a/library/structure/graph/topological_sort/topological_sorter.e
+++ b/library/structure/graph/topological_sort/topological_sorter.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description	: "[
 			Topological sorter.
 			Used to produce a total order on a set of
@@ -61,7 +61,7 @@ feature -- Initialization
 			-- Ensure `e' and `f' are inserted (no effect if they already were):
 			record_element (e)
 			record_element (f)
-			
+
 			x := index_of_element.item (e)
 			y := index_of_element.item (f)
 			predecessor_count.put (predecessor_count.item (y) + 1, y)
@@ -77,7 +77,7 @@ feature -- Access
 		do
 			Result := has_cycle
 		end
-	
+
 	cycle_list: LIST [G] is
 			-- Elements involved in cycles
 		require
@@ -88,7 +88,7 @@ feature -- Access
 			void_iff_none: (not cycle_found) = (Result = Void)
 			not_empty_if_cycle: cycle_found implies (not Result.is_empty)
 		end
-	
+
 	sorted_elements: LIST [G] is
 			-- List, in an order respecting the constraints, of all
 			-- the elements that can be ordered in that way
@@ -260,7 +260,7 @@ feature {NONE} -- Implementation
 	has_cycle: like cycle_found
 			-- Internal attribute with same value as `cycle_found'.
 			-- (needed because `cycle_found' has precondition `done'.)
-	
+
 	cycle_list_impl: like cycle_list
 			-- Internal attribute with same value as `cycle_list'.
 			-- (needed because `cycle_list' has precondition `done'.)
@@ -272,7 +272,7 @@ feature {NONE} -- Implementation
 
 	index_of_element: HASH_TABLE [INTEGER, G]
 			-- Index of every element
-	
+
 	element_of_index: ARRAY [G]
 			-- For every assigned index, gives the associated element
 
@@ -341,13 +341,13 @@ feature {NONE} -- Implementation
 		end
 
 invariant
-	
+
 	elements_not_void:			element_of_index /= Void
 	hash_table_not_void:		index_of_element /= Void
 	predecessor_count_not_void:	predecessor_count /= Void
 	successors_not_void:		successors /= Void
 	candidates_not_void:		candidates /= Void
-	
+
 	element_count:			element_of_index.count = count
 	predecessor_list_count:	predecessor_count.count = count
 	successor_list_count:	successors.count = count

--- a/library/structure/graph/tree/b_tree.e
+++ b/library/structure/graph/tree/b_tree.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "B-Trees: implementation of balanced search trees."
 	author: "Olivier Jeger"
 	license: "Eiffel Forum License v2 (see forum.txt)"

--- a/library/structure/graph/tree/balanced_search_tree.e
+++ b/library/structure/graph/tree/balanced_search_tree.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Balanced search trees."
 	author: "Olivier Jeger"
 	license: "Eiffel Forum License v2 (see forum.txt)"
@@ -86,7 +86,7 @@ feature -- Status report
 
 	is_sorted: BOOLEAN is
 			-- Are all tree items in sorted order?
-			-- (Order can be destroyed by modifying 
+			-- (Order can be destroyed by modifying
 			-- item values after insertion in tree.)
 		deferred
 		end
@@ -105,7 +105,7 @@ feature -- Status report
 
 	child_writable: BOOLEAN is False
 			-- Is there a current `child_item' that may be modified?
-	
+
 	writable_child: BOOLEAN is False
 			-- Is there a current child that may be modified?
 			-- False because balanced trees are self-organizing.
@@ -119,7 +119,7 @@ feature -- Element change
 	put, extend (v: G) is
 			-- Put `v' at proper position in tree
 			-- (unless `v' exists already).
-			-- (Reference or object equality, 
+			-- (Reference or object equality,
 			-- based on `object_comparison'.)
 		require
 			item_not_void: v /= Void
@@ -208,7 +208,7 @@ feature {BALANCED_SEARCH_TREE} -- Inapplicable
 feature {NONE} -- Implementation
 
 invariant
-	
+
 	object_comparison: object_comparison
 
 end -- class BALANCED_SEARCH_TREE

--- a/library/structure/graph/union_find/union_find_structure.e
+++ b/library/structure/graph/union_find/union_find_structure.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 			Union-find data structure.
 			Element lookup with `find' completes in O(log(n))
@@ -45,7 +45,7 @@ feature -- Access
 			set_index, root_index, par: INTEGER
 		do
 			set_index := index_of_element.item (e)
-			
+
 			-- Traverse the "tree" upwards to get the root index.
 			from
 				root_index := set_index
@@ -56,7 +56,7 @@ feature -- Access
 				-- Get the parent set number until the "root" set number is found.
 				root_index := parent.item (root_index)
 			end
-			
+
 			-- Optimize `parent' array for "root" access in one single step.
 			from
 			until
@@ -66,7 +66,7 @@ feature -- Access
 				parent.put (root_index, set_index)
 				set_index := par
 			end
-			
+
 			Result := root_index
 		ensure
 			valid_identifier: valid_identifier (Result)
@@ -189,7 +189,7 @@ feature -- Element change
 				elements_in_set.force (1, count)
 				next_element_in_set.force (-1, count)
 				last_element_in_set.force (count, count)
-				
+
 				-- Update `valid_identifiers' list.
 				next_valid_identifier.force (-1, count)
 				if count = 1 then
@@ -227,7 +227,7 @@ feature -- Basic operations
 		do
 			-- `a_set_identifier' and `other_set_identifier' are both root elements
 			-- (because of `valid_identifier').
-			
+
 			-- Make smaller set part of larger set.
 			if item_count (a_identifier) >= item_count (other_identifier) then
 				merge_sets (a_identifier, other_identifier)
@@ -260,7 +260,7 @@ feature {NONE} -- Implementation
 
 	next_element_in_set: ARRAY [INTEGER]
 			-- "Linked list" of elements in the same set (realized as array). Terminated by "-1"
-	
+
 	last_element_in_set: ARRAY [INTEGER]
 			-- Positions of the entry "-1" in `next_element_in_set' for each set.
 
@@ -270,7 +270,7 @@ feature {NONE} -- Implementation
 	next_valid_identifier: ARRAY [INTEGER]
 			-- Forward links of "doubly linked list" of valid identifiers
 			-- Terminated by "-1"
-	
+
 	prev_valid_identifier: ARRAY [INTEGER]
 			-- Backward links of "doubly linked list" of valid identifiers
 			-- Terminated by "-1"
@@ -289,13 +289,13 @@ feature {NONE} -- Implementation
 
 			-- Reparent set items.
 			parent.put (a_identifier, other_identifier)
-			
+
 			-- Update element list.
 			last_of_larger := last_element_in_set.item (a_identifier)
 			last_of_smaller := last_element_in_set.item (other_identifier)
 			last_element_in_set.put (last_of_smaller, a_identifier)
 			next_element_in_set.put (other_identifier, last_of_larger)
-			
+
 			-- Invalidate `other_identifier'.
 			remove_identifier (other_identifier)
 
@@ -304,8 +304,8 @@ feature {NONE} -- Implementation
 		ensure
 			set_count: set_count = old set_count - 1
 			first_set_invalid: not valid_identifier (other_identifier)
-			new_set_size: item_count (a_identifier) = 
-						  (old item_count (a_identifier) + 
+			new_set_size: item_count (a_identifier) =
+						  (old item_count (a_identifier) +
 						   old item_count (other_identifier))
 		end
 
@@ -341,7 +341,7 @@ invariant
 
 	parent_count: parent.count = elements.count
 	hash_table_count: index_of_element.count = count
-	
+
 	set_count: sets.count = set_count
 	same_count: identifiers.count = set_count
 

--- a/library/traffic_building_randomizer.e
+++ b/library/traffic_building_randomizer.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that distribute buildings randomly over the city"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_city.e
+++ b/library/traffic_city.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "City with a traffic system of a region."
 	date: "$Date: 2006/01/09 12:23:40 $"
 	revision: "$Revision: 1.5 $"

--- a/library/traffic_city_item.e
+++ b/library/traffic_city_item.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Elements that belong to the city"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_color.e
+++ b/library/traffic_color.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Color objects (independent of the visualization to be used, vision2 or em)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_constants.e
+++ b/library/traffic_constants.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Constants for Traffic"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_exchange_segment.e
+++ b/library/traffic_exchange_segment.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 		Segment that represent the changing from one means of transportation to the other. 
 		Will most probably be invisible.

--- a/library/traffic_graph.e
+++ b/library/traffic_graph.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Traffic graph containing nodes and connections"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_grid.e
+++ b/library/traffic_grid.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Grid that stores what objects occupy positions on the city"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_id_manager.e
+++ b/library/traffic_id_manager.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Manager for road ids"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_leg.e
+++ b/library/traffic_leg.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Part of a TRAFFIC_ROUTE,%
 		% goes from `origin' to `destination' using a SINGLE line or walking"
 	date: "$Date$"

--- a/library/traffic_line.e
+++ b/library/traffic_line.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Public transportation line where objects of a given type move along."
 	date: "$Date: 2010-06-28 20:14:26 +0200 (Пн, 28 июн 2010) $"
 	revision: "$Revision: 1133 $"

--- a/library/traffic_line_cursor.e
+++ b/library/traffic_line_cursor.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Cursor for TRAFFIC_LINE objects (to avoid moving internal cursors of the line)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_line_segment.e
+++ b/library/traffic_line_segment.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Line segment of line from one station to another."
 	date: "$Date: 2010-06-28 20:14:26 +0200 (Пн, 28 июн 2010) $"
 	revision: "$Revision: 1133 $"

--- a/library/traffic_map_loader.e
+++ b/library/traffic_map_loader.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Loader that handles the city loading from xml and dump files"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_node.e
+++ b/library/traffic_node.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Node in the graph (a node is an endpoint of a connection)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_point.e
+++ b/library/traffic_point.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Point (coordinate) objects for visualization independent traffic representations"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_point_randomizer.e
+++ b/library/traffic_point_randomizer.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Randomizer that allows to produce lists of random positions that are on the city "
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_polygon.e
+++ b/library/traffic_polygon.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Objects that ..."
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_road.e
+++ b/library/traffic_road.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Roads in the city (e.g. streets, lightrailroads, railroads)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_road_segment.e
+++ b/library/traffic_road_segment.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Directed road connections that connect two stations"
 	date: "$Date: 2006-03-27 19:42:12 +0200 (Mon, 27 Mar 2006) $"
 	revision: "$Revision: 601 $"

--- a/library/traffic_route.e
+++ b/library/traffic_route.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Represents a route from one TRAFFIC_STATION to another"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_route_calculator.e
+++ b/library/traffic_route_calculator.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "A route calculator facility"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_route_randomizer.e
+++ b/library/traffic_route_randomizer.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Random route generator (used for providing passengers with their routes)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_segment.e
+++ b/library/traffic_segment.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Deferred segments for the graph"
 	date: "$Date: 2006-03-27 19:42:12 +0200 (Mon, 27 Mar 2006) $"
 	revision: "$Revision: 601 $"

--- a/library/traffic_segment_state.e
+++ b/library/traffic_segment_state.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "State of line segment."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/traffic_simple_line.e
+++ b/library/traffic_simple_line.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Transportation lines (not showing contracts)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_simple_stop.e
+++ b/library/traffic_simple_stop.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "A simple version of the class TRAFFIC_STOP"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_station.e
+++ b/library/traffic_station.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Stations (or more generally places connected through lines or roads)"
 	date: "$Date: 2010-06-28 20:14:26 +0200 (Пн, 28 июн 2010) $"
 	revision: "$Revision: 1133 $"

--- a/library/traffic_station_information.e
+++ b/library/traffic_station_information.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Additional information on a station."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/traffic_stop.e
+++ b/library/traffic_stop.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Stops that belong to a line and are nodes of the graph"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_time.e
+++ b/library/traffic_time.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "This object represent the time in the city model"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/traffic_vision2.ecf
+++ b/library/traffic_vision2.ecf
@@ -16,13 +16,13 @@
 			<concurrency support="none"/>
 			<void_safety support="none"/>
 		</capability>
-		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf" readonly="true"/>
+		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf"/>
 		<library name="gobo_kernel" location="$ISE_LIBRARY\library\gobo\gobo_kernel.ecf"/>
 		<library name="gobo_structure" location="$ISE_LIBRARY\library\gobo\gobo_structure.ecf"/>
 		<library name="gobo_time" location="$ISE_LIBRARY\library\gobo\gobo_time.ecf"/>
 		<library name="gobo_xml" location="$ISE_LIBRARY\library\gobo\gobo_xml.ecf"/>
-		<library name="time" location="$ISE_LIBRARY\library\time\time.ecf" readonly="true"/>
-		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2.ecf" readonly="true"/>
+		<library name="time" location="$ISE_LIBRARY\library\time\time.ecf"/>
+		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2.ecf"/>
 		<cluster name="traffic" location=".\" recursive="true">
 			<option>
 				<assertions precondition="true" postcondition="true" check="true" invariant="true" loop="true" supplier_precondition="true"/>

--- a/library/traffic_vision2.ecf
+++ b/library/traffic_vision2.ecf
@@ -2,7 +2,7 @@
 <system xmlns="http://www.eiffel.com/developers/xml/configuration-1-21-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-21-0 http://www.eiffel.com/developers/xml/configuration-1-21-0.xsd" name="traffic" uuid="9FAB6FC9-CD89-4C61-82ED-081CA0AA1410" library_target="traffic">
 	<target name="traffic">
 		<root all_classes="true"/>
-		<option warning="warning" full_class_checking="false" is_attached_by_default="true" is_obsolete_routine_type="true" syntax="transitional" manifest_array_type="mismatch_warning">
+		<option warning="warning" full_class_checking="false" is_attached_by_default="true" is_obsolete_routine_type="true" syntax="standard" manifest_array_type="mismatch_warning">
 			<warning name="export_class_missing" enabled="false"/>
 			<warning name="old_verbatim_strings" enabled="false"/>
 			<warning name="once_in_generic" enabled="false"/>

--- a/library/traffic_vision2_safe.ecf
+++ b/library/traffic_vision2_safe.ecf
@@ -14,17 +14,17 @@
 		<setting name="dead_code_removal" value="feature"/>
 		<capability>
 			<concurrency support="none"/>
-			<void_safety support="none" use="none"/>
+			<void_safety support="none"/>
 		</capability>
-		<library name="base-safe" location="$ISE_LIBRARY\library\base\base-safe.ecf" readonly="false"/>
-		<library name="eiffel_time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
-		<library name="gobo_kernel" location="$ISE_LIBRARY\library\gobo\gobo_kernel-safe.ecf" readonly="false"/>
-		<library name="gobo_structure" location="$ISE_LIBRARY\library\gobo\gobo_structure-safe.ecf" readonly="false"/>
-		<library name="gobo_time" location="$ISE_LIBRARY\contrib\library\gobo\library\time\src\library.ecf"/>
-		<library name="gobo_xml" location="$ISE_LIBRARY\contrib\library\gobo\library\xml\src\library.ecf"/>
-		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2-safe.ecf" readonly="false"/>
-		<cluster name="traffic" location=".\">
-			<option is_attached_by_default="true" syntax="transitional">
+		<library name="base" location="$ISE_LIBRARY\library\base\base-safe.ecf"/>
+		<library name="gobo_kernel" location="$ISE_LIBRARY\library\gobo\gobo_kernel-safe.ecf"/>
+		<library name="gobo_structure" location="$ISE_LIBRARY\library\gobo\gobo_structure-safe.ecf"/>
+		<library name="gobo_time" location="$ISE_LIBRARY\library\gobo\gobo_time-safe.ecf"/>
+		<library name="gobo_xml" location="$ISE_LIBRARY\library\gobo\gobo_xml-safe.ecf"/>
+		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
+		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2-safe.ecf"/>
+		<cluster name="traffic" location=".\" recursive="true">
+			<option>
 				<assertions precondition="true" postcondition="true" check="true" invariant="true" loop="true" supplier_precondition="true"/>
 			</option>
 			<file_rule>
@@ -32,18 +32,6 @@
 				<exclude>EIFGENs</exclude>
 				<exclude>visualization/em</exclude>
 			</file_rule>
-			<cluster name="building" location=".\building\" recursive="true"/>
-			<cluster name="factory" location=".\factory\" recursive="true"/>
-			<cluster name="input" location=".\input\" recursive="true"/>
-			<cluster name="moving" location=".\moving\" recursive="true"/>
-			<cluster name="structure" location=".\structure\" recursive="true"/>
-			<cluster name="type" location=".\type\" recursive="true"/>
-			<cluster name="utility" location=".\utility\" recursive="true"/>
-			<cluster name="visualization" location=".\visualization\" recursive="true">
-				<file_rule>
-					<exclude>em</exclude>
-				</file_rule>
-			</cluster>
 		</cluster>
 	</target>
 </system>

--- a/library/traffic_vision2_safe.ecf
+++ b/library/traffic_vision2_safe.ecf
@@ -2,7 +2,7 @@
 <system xmlns="http://www.eiffel.com/developers/xml/configuration-1-21-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-21-0 http://www.eiffel.com/developers/xml/configuration-1-21-0.xsd" name="traffic" uuid="9FAB6FC9-CD89-4C61-82ED-081CA0AA1410" library_target="traffic-safe">
 	<target name="traffic-safe">
 		<root all_classes="true"/>
-		<option warning="warning" full_class_checking="false" is_attached_by_default="true" is_obsolete_routine_type="true" manifest_array_type="mismatch_warning">
+		<option warning="warning" full_class_checking="false" is_attached_by_default="true" is_obsolete_routine_type="true" syntax="standard" manifest_array_type="mismatch_warning">
 			<warning name="export_class_missing" enabled="false"/>
 			<warning name="old_verbatim_strings" enabled="false"/>
 			<warning name="once_in_generic" enabled="false"/>

--- a/library/type/traffic_type.e
+++ b/library/type/traffic_type.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Describes types of TRAFFIC_ROADs and TRAFFIC_LINEs"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision: 1133 $"
@@ -19,7 +19,7 @@ feature -- Access
 			-- String representation
 
 	speed: REAL_64 is 10.0
-			-- Default speed 
+			-- Default speed
 
 feature -- Output
 

--- a/library/type/traffic_type_bus.e
+++ b/library/type/traffic_type_bus.e
@@ -1,23 +1,23 @@
-indexing
+note
 	description: "Bus type."
 	date: "$Date: 2006-06-26 20:01:11$"
 	revision: "$Revision: 737 $"
 
 class
 	TRAFFIC_TYPE_BUS
-	
+
 inherit
 	TRAFFIC_TYPE_LINE
-	
+
 create
 	make
-	
+
 feature -- Creation
 
 	make is
-			-- Create new bus type. 
+			-- Create new bus type.
 		do
 			name := "bus"
 		end
-	
+
 end

--- a/library/type/traffic_type_dispatcher_taxi.e
+++ b/library/type/traffic_type_dispatcher_taxi.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Dispatcher taxi type."
 	date: "$Date: 2006-06-26 20:01:11 $"
 	revision: "$Revision: 602 $"

--- a/library/type/traffic_type_event_taxi.e
+++ b/library/type/traffic_type_event_taxi.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Event taxi type."
 	date: "$Date: 2006-06-26 $"
 	revision: "$Revision: 602 $"

--- a/library/type/traffic_type_lightrail.e
+++ b/library/type/traffic_type_lightrail.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Lightrail road type."
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/type/traffic_type_line.e
+++ b/library/type/traffic_type_line.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Base class for line types."
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/type/traffic_type_rail.e
+++ b/library/type/traffic_type_rail.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Rail type."
 	date: "$Date: 2006-07-25 14:34:57 +0200 (Вт, 25 июл 2006) $"
 	revision: "$Revision: 737 $"
@@ -8,16 +8,16 @@ class
 
 inherit
 	TRAFFIC_TYPE_LINE
-	
+
 create
 	make
-	
+
 feature -- Creation
 
 	make is
-			-- Create new rail type. 
+			-- Create new rail type.
 		do
 			name := "rail"
 		end
-		
+
 end

--- a/library/type/traffic_type_railroad.e
+++ b/library/type/traffic_type_railroad.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Railroad type."
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/type/traffic_type_road.e
+++ b/library/type/traffic_type_road.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Base class for road's types"
 	date: "$Date: 6/6/2006$"
 	revision: "$Revision$"

--- a/library/type/traffic_type_street.e
+++ b/library/type/traffic_type_street.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Street type."
 	date: "$Date: 2006-07-25 17:14:39 +0200 (Вт, 25 июл 2006) $"
 	revision: "$Revision: 742 $"
@@ -8,16 +8,16 @@ class
 
 inherit
 	TRAFFIC_TYPE_ROAD
-	
+
 create
 	make
-	
+
 feature -- Creation
 
 	make is
-			-- Create new street type. 
+			-- Create new street type.
 		do
 			name := "street"
 		end
-			
+
 end

--- a/library/type/traffic_type_tram.e
+++ b/library/type/traffic_type_tram.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Tram type."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/type/traffic_type_walking.e
+++ b/library/type/traffic_type_walking.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Walking type."
 	date: "$Date: 2009-08-21 13:35:22 +0200 (Пт, 21 авг 2009) $"
 	revision: "$Revision: 1098 $"

--- a/library/utility/gl_tools/gl_vector_3d.e
+++ b/library/utility/gl_tools/gl_vector_3d.e
@@ -1,9 +1,9 @@
-indexing
+note
 	description: "[
 		
 		A 3-dimensional vector that can be used with OpenGL.
 		Note: this is a simple implementation which doesn't allow any mathematics.
-		
+
 	]"
 	date: "$Date: 2005/09/05 11:08:11 $"
 	revision: "$Revision: 1.1 $"
@@ -14,9 +14,9 @@ class
 inherit
 	ANY
 		redefine
-			out 
+			out
 		end
-	
+
 	DEBUG_OUTPUT
 		redefine
 			out
@@ -24,7 +24,7 @@ inherit
 
 create
 	make_xyz
-	
+
 feature {NONE} -- Initialisation
 
 	make_xyz (a_x, a_y, a_z: G) is
@@ -41,7 +41,7 @@ feature {NONE} -- Initialisation
 			y_set: y = a_y
 			z_set: z = a_z
 		end
-	
+
 	make_from_other (other: like Current) is
 			-- Initialise `Current' with values from `other'.
 		require
@@ -55,7 +55,7 @@ feature {NONE} -- Initialisation
 		end
 
 feature -- Access
-		
+
 	x: G is
 			-- First element
 		do
@@ -63,7 +63,7 @@ feature -- Access
 		ensure
 			result_exists: Result /= Void
 		end
-		
+
 	y: G is
 			-- Second element
 		do
@@ -71,7 +71,7 @@ feature -- Access
 		ensure
 			result_exists: Result /= Void
 		end
-		
+
 	z: G is
 			-- Third element
 		do
@@ -88,7 +88,7 @@ feature -- Access
 			tmp := array.to_c
 			Result := $tmp
 		end
-	
+
 feature -- Element change
 
 	set_xyz (a, b, c: G) is
@@ -116,8 +116,8 @@ feature -- Support
 		end
 
 feature {NONE} -- Implementation
-	
+
 	array: ARRAY [G]
 			-- The array to hold the elements
-	
+
 end

--- a/library/utility/gl_tools/gl_vector_4d.e
+++ b/library/utility/gl_tools/gl_vector_4d.e
@@ -1,9 +1,9 @@
-indexing
+note
 	description: "[
 		
 		A 4-dimensional vector that can be used with OpenGL.
 		Note: this is a simple implementation which doesn't allow any mathematics.
-		
+
 	]"
 	date: "$Date: 2005/09/05 11:08:11 $"
 	revision: "$Revision: 1.1 $"
@@ -13,14 +13,14 @@ class
 
 inherit
 	GL_VECTOR_3D [G]
-		redefine 
+		redefine
 			out,
 			debug_output
 		 end
 
 create
 	make_xyzt
-	
+
 feature {NONE} -- Initialisation
 
 	make_xyzt (a_x, a_y, a_z, a_t: G) is
@@ -39,9 +39,9 @@ feature {NONE} -- Initialisation
 			z_set: z = a_z
 			t_set: t = a_t
 		end
-	
+
 feature -- Access
-		
+
 	t: G is
 			-- Fourth element
 		do
@@ -49,7 +49,7 @@ feature -- Access
 		ensure
 			result_exists: Result /= Void
 		end
-	
+
 feature -- Element change
 
 	set_xyzt (a_x, a_y, a_z, a_t: G) is

--- a/library/utility/traffic_error_handler.e
+++ b/library/utility/traffic_error_handler.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 

--- a/library/utility/traffic_error_messages.e
+++ b/library/utility/traffic_error_messages.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 
 		Provide mapping of error constants from EM_ERROR_CODES to string messages.
@@ -28,9 +28,9 @@ feature {NONE} -- Initialisation
 			Error_messages.force ("Directory {1} does not exist", Traffic_error_directory_does_not_exist)
 			Error_messages.force ("Xml file {1} does not exist", Traffic_error_xml_file_does_not_exist)
 			Error_messages.force ("Dump file loading {1} did not work", Traffic_error_loading_dump_file)
-			
+
 			-- Todo add other errors
-			
+
 			-- Miscellaneous error messages
 			Error_messages.force ("A 'this should never happen' error has occured in section '{1}'. Please notify the developers", Traffic_error_this_should_never_happen)
 		end

--- a/library/utility/traffic_shared_error_handler.e
+++ b/library/utility/traffic_shared_error_handler.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 

--- a/library/visualization/traffic_city_widget.e
+++ b/library/visualization/traffic_city_widget.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Widgets that display a city"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/traffic_view.e
+++ b/library/visualization/traffic_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for a city item"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/traffic_view_container.e
+++ b/library/visualization/traffic_view_container.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Container for city item views of a certain type"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/traffic_view_factory.e
+++ b/library/visualization/traffic_view_factory.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Factory for city item views"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/drawable/canvas.e
+++ b/library/visualization/vision2/drawable/canvas.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 			Graphical picture stored as a two dimensional map of pixels.

--- a/library/visualization/vision2/drawable/drawable_circle.e
+++ b/library/visualization/vision2/drawable/drawable_circle.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Circles that will scale when zooming in EV_CANVAS"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/drawable_icon.e
+++ b/library/visualization/vision2/drawable/drawable_icon.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[ 
 			Sub pixmaps for use with EV_CANVAS not scaling.

--- a/library/visualization/vision2/drawable/drawable_object.e
+++ b/library/visualization/vision2/drawable/drawable_object.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 					Objects that can be drawn on EV_CANVAS and

--- a/library/visualization/vision2/drawable/drawable_object_container.e
+++ b/library/visualization/vision2/drawable/drawable_object_container.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Drawable object that is a container for other drawable objects"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/drawable/drawable_pixmap.e
+++ b/library/visualization/vision2/drawable/drawable_pixmap.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Sub pixmaps for use with EV_CANVAS, scaling"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/drawable_polygon.e
+++ b/library/visualization/vision2/drawable/drawable_polygon.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Polygon that will scale when zooming in EV_CANVAS"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/drawable_polyline.e
+++ b/library/visualization/vision2/drawable/drawable_polyline.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Polyline that will scale when zooming in EV_CANVAS"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/drawable_rounded_rectangle.e
+++ b/library/visualization/vision2/drawable/drawable_rounded_rectangle.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 					Rounded rectangle that will scale when zooming in EV_CANVAS

--- a/library/visualization/vision2/drawable/drawable_spot.e
+++ b/library/visualization/vision2/drawable/drawable_spot.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "[
 					Circle that wont scale when zooming in

--- a/library/visualization/vision2/drawable/drawable_text.e
+++ b/library/visualization/vision2/drawable/drawable_text.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Text labels for use with EV_CANVAS"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/real_coordinate.e
+++ b/library/visualization/vision2/drawable/real_coordinate.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "A position in a 2 dimensional space as REALs (x, y)"
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/real_rectangle.e
+++ b/library/visualization/vision2/drawable/real_rectangle.e
@@ -1,4 +1,4 @@
-indexing
+note
 
 	description: "Rectangular areas."
 	status:	"See notice at end of class"

--- a/library/visualization/vision2/drawable/zoomable_canvas.e
+++ b/library/visualization/vision2/drawable/zoomable_canvas.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description:
 		"[
 			Canvas with comfortable zooming and panning abilities.

--- a/library/visualization/vision2/time/traffic_shared_time.e
+++ b/library/visualization/vision2/time/traffic_shared_time.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Singleton that simulates time of the day"
 	date: "$Date$"
 

--- a/library/visualization/vision2/time/traffic_vision2_time.e
+++ b/library/visualization/vision2/time/traffic_vision2_time.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Timing facilities with vision2"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/touch/touch_paris_objects.e
+++ b/library/visualization/vision2/touch/touch_paris_objects.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Predefined objects of the city Paris"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/touch/tourism.e
+++ b/library/visualization/vision2/touch/tourism.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "[
 					Contains all the predefines and classes to run 'explore'.
 					]"

--- a/library/visualization/vision2/touch/traffic_console.e
+++ b/library/visualization/vision2/touch/traffic_console.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Traffic console for output in examples"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/touch/traffic_main_window.e
+++ b/library/visualization/vision2/touch/traffic_main_window.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Vision2 Main window for touch examples, containing a console and a button plus a city canvas"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/traffic_city_canvas.e
+++ b/library/visualization/vision2/traffic_city_canvas.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "City widget for vision2"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/traffic_vs_view_container.e
+++ b/library/visualization/vision2/traffic_vs_view_container.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Container for vision2 city item views"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_building_icon_view.e
+++ b/library/visualization/vision2/views/traffic_building_icon_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Iconic view of a building (for special buildings such as landmarks)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_building_simple_view.e
+++ b/library/visualization/vision2/views/traffic_building_simple_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Simple view for buildings (grey rectangle)"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_building_view.e
+++ b/library/visualization/vision2/views/traffic_building_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for buildings, subclasses make this class effective"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_line_segment_view.e
+++ b/library/visualization/vision2/views/traffic_line_segment_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for line segments"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_line_view.e
+++ b/library/visualization/vision2/views/traffic_line_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for transportation lines"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_moving_deferred_view.e
+++ b/library/visualization/vision2/views/traffic_moving_deferred_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for movings, subclasses make this class effective"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_moving_icon_view.e
+++ b/library/visualization/vision2/views/traffic_moving_icon_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for moving items such as trams, passengers, etc."
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_moving_view.e
+++ b/library/visualization/vision2/views/traffic_moving_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for moving items such as trams, passengers, etc."
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_road_view.e
+++ b/library/visualization/vision2/views/traffic_road_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for roads"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_route_view.e
+++ b/library/visualization/vision2/views/traffic_route_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for routes"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_station_view.e
+++ b/library/visualization/vision2/views/traffic_station_view.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "View for stations"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_vs_view.e
+++ b/library/visualization/vision2/views/traffic_vs_view.e
@@ -1,5 +1,5 @@
 
-indexing
+note
 	description: "Deferred class for all vision2 city item views"
 	date: "$Date$"
 	revision: "$Revision$"

--- a/library/visualization/vision2/views/traffic_vs_view_factory.e
+++ b/library/visualization/vision2/views/traffic_vs_view_factory.e
@@ -1,4 +1,4 @@
-indexing
+note
 	description: "Factory for vision2 city item views"
 	date: "$Date$"
 	revision: "$Revision$"


### PR DESCRIPTION
Updated library to standard syntax:
- Library ECF files updated (and unified, e.g. used libraries' folders)
- Changed `indexing` to `note` in library classes (hopefully all that weren't yet updated)
@jvelilla: Could you please review?